### PR TITLE
caldav: handle shared calendar signature verification gracefully

### DIFF
--- a/caldav/caldav.go
+++ b/caldav/caldav.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -59,7 +60,11 @@ func readEventCard(event *ical.Event, eventCard protonmail.CalendarEventCard, us
 	}*/
 
 	if err := md.SignatureError; err != nil {
-		return nil, fmt.Errorf("caldav/readEventCard: signature error: (%w)", err)
+		// Signature verification can fail for shared calendar events when
+		// the signer's key isn't available (e.g. different user, rotated
+		// keys). Log the error but continue — the event data is still
+		// readable, we just can't verify who signed it.
+		log.Printf("caldav/readEventCard: signature verification failed (non-fatal): %v", err)
 	}
 
 	children := decoded.Events()
@@ -359,14 +364,15 @@ func (b *backend) QueryCalendarObjects(ctx context.Context, path string, query *
 		return nil, fmt.Errorf("caldav/QueryCalendarObjects: error decrypting keyring: (%w)", err)
 	}
 
-	cos := make([]caldav.CalendarObject, len(events))
+	var cos []caldav.CalendarObject
 	for i, event := range events {
 		co, err := getCalendarObject(b, calId, calKr, event, bootstrap.CalendarSettings)
 		if err != nil {
-			return nil, fmt.Errorf("caldav/QueryCalendarObjects: error creating calendar object for event %d: (%w)", i, err)
+			log.Printf("caldav/QueryCalendarObjects: skipping event %d (ID: %s) due to error: %v", i, event.ID, err)
+			continue
 		}
 
-		cos[i] = *co
+		cos = append(cos, *co)
 	}
 
 	return cos, nil


### PR DESCRIPTION
## Summary

When accessing **shared calendars** via CalDAV, event signature verification fails because the signer's key (the calendar owner) isn't available in the reader's keyring. This causes two problems:

1. `readEventCard` returns a fatal error on `md.SignatureError`, crashing the entire request
2. `QueryCalendarObjects` aborts on the first event that fails to decode, blocking access to all events

This PR makes both paths resilient:

- **`readEventCard`**: `SignatureError` is now non-fatal — logged as a warning but execution continues. The event data is still readable via E2E decryption; only the authorship signature can't be verified.
- **`QueryCalendarObjects`**: Individual events that fail to decode are skipped (with a log message) instead of aborting the entire query. This matches the resilient error-handling pattern and prevents one problematic event from blocking access to all others.

## Reproduction

1. User A shares a Proton Calendar with User B
2. User B connects via ferroxide CalDAV
3. Querying the shared calendar fails with: `signature made by unknown entity`

## Testing

Tested with a real shared Proton Calendar (owner ≠ reader). All 13 events from the shared calendar now load correctly where they previously caused fatal errors. Read and write operations (PUT/DELETE) on the shared calendar also work as expected.

## Changes

- `caldav/caldav.go`: Add `log` import
- `caldav/caldav.go` `readEventCard()`: Make `SignatureError` non-fatal (log + continue)
- `caldav/caldav.go` `QueryCalendarObjects()`: Skip failed events instead of returning error